### PR TITLE
Test that exported subs are truly lexical

### DIFF
--- a/t/cross-package.t
+++ b/t/cross-package.t
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+use Exporter::Lexical ();
+
+sub foo { 'foo' }
+
+is(foo(), "foo");
+{
+    BEGIN { Exporter::Lexical::lexical_import(foo => sub { "FOO" }) }
+    package Forget::Me::Not;
+    ::is(foo(), "FOO");
+}
+is(foo(), "foo");
+
+done_testing;


### PR DESCRIPTION
The existing tests just check that the exported subs _do_ go out of scope when they hit a closing brace. i.e. the behaviour already found in Sub::Exporter::Lexical.

There should be a test that exported subs _don't_ go out of scope when they hit a `package` statement.
